### PR TITLE
fix: change Scanln for select {} for services

### DIFF
--- a/cmd/dyndns/cron.go
+++ b/cmd/dyndns/cron.go
@@ -2,7 +2,6 @@ package main
 
 import (
 	"dyndns-cloudflare/pkg/ipfinder"
-	"fmt"
 	"github.com/robfig/cron"
 	"log"
 )
@@ -39,8 +38,5 @@ func RunCronJobs(clientApi *ipfinder.ApiClient) {
 
 	c.Start()
 
-	_, err = fmt.Scanln()
-	if err != nil {
-		log.Fatal(err)
-	}
+	select {}
 }


### PR DESCRIPTION
# Description
Changed the Scanln field that keeps the main process alive does not work when the application is ran as a systemd service as there is no user input. Replaced the Scanln by select {}

## Checklist for the reviewers
- [x] Verify coding style/standard
- [ ] New tests have been added
- [x] Check if tests if passed
- [x] Verify all workflow pass