### PR TITLE
Add rate limit management

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,5 +1,5 @@
 # DynDNS-Cloudflare
-
+[![Go build and test](https://github.com/walidoow/dyndns-cloudflare/actions/workflows/golang-build.yml/badge.svg)](https://github.com/walidoow/dyndns-cloudflare/actions/workflows/golang-build.yml) [![Create Release on Tag Push](https://github.com/walidoow/dyndns-cloudflare/actions/workflows/create-release.yml/badge.svg)](https://github.com/walidoow/dyndns-cloudflare/actions/workflows/create-release.yml)
 ## Overview
 
 DynDNS-Cloudflare is a dynamic DNS update tool designed to work with Cloudflare's API. This tool helps in automatically

--- a/pkg/ipfinder/finder.go
+++ b/pkg/ipfinder/finder.go
@@ -17,6 +17,8 @@ func New() *ApiClient {
 
 	for _, ipProvider := range ipproviders.IpProviders {
 		if ipProvider.IsEnabled {
+			// Calculated field for rate limiting
+			ipProvider.PeriodSizeSec = float32(ipProvider.RateLimit) / float32(ipProvider.RateLimitType)
 			client.ipProviders = append(client.ipProviders, ipProvider)
 		}
 	}
@@ -25,14 +27,35 @@ func New() *ApiClient {
 
 // GetCurrentIp returns the current IP from the next available IP Provider
 func (ac *ApiClient) GetCurrentIp() string {
-	var ipProvider ipproviders.IpProvider = ac.ipProviders[ac.index]
-
-	response, err := ipProvider.FuncGetIp()
+	// TODO: Add error return to the function
+	currentIpProvider, err := selectNextAvailableIpProvider(ac)
 	if err != nil {
 		return "" // TODO: handle error
 	}
-	ipProvider.LastUsage = time.Now().Unix()
 
-	ac.index = (ac.index + 1) % len(ac.ipProviders)
+	response, err := currentIpProvider.FuncGetIp()
+	if err != nil {
+		return "" // TODO: handle error
+	}
+	currentIpProvider.LastUsage = time.Now().Unix()
+
 	return response
+}
+
+// selectNextAvailableIpProvider returns the next available IP Provider.
+// If all IP Providers are rate limited, it returns an error.
+func selectNextAvailableIpProvider(ac *ApiClient) (ipproviders.IpProvider, error) {
+	for i := 0; i < len(ac.ipProviders); i++ {
+		ac.index = ac.calculateNextIndex()
+		ipProvider := ac.ipProviders[ac.index]
+		if !ipProvider.IsRateLimited || time.Now().Unix()-ipProvider.LastUsage >= int64(ipProvider.PeriodSizeSec) {
+			return ipProvider, nil
+		}
+	}
+	return ipproviders.IpProvider{}, nil
+}
+
+// calculateNextIndex returns the next index in the slice of IP Providers
+func (ac *ApiClient) calculateNextIndex() int {
+	return (ac.index + 1) % len(ac.ipProviders)
 }

--- a/pkg/ipfinder/finder.go
+++ b/pkg/ipfinder/finder.go
@@ -27,7 +27,6 @@ func New() *ApiClient {
 
 // GetCurrentIp returns the current IP from the next available IP Provider
 func (ac *ApiClient) GetCurrentIp() string {
-	// TODO: Add error return to the function
 	currentIpProvider, err := selectNextAvailableIpProvider(ac)
 	if err != nil {
 		return "" // TODO: handle error

--- a/pkg/ipfinder/ipproviders/ipapy.go
+++ b/pkg/ipfinder/ipproviders/ipapy.go
@@ -10,9 +10,9 @@ func GetIpProviderIpapi() IpProvider {
 	return IpProvider{
 		Name:          "Ipapi",
 		ApiUrl:        "https://ipapi.co/json/",
-		IsRateLimited: false,
-		RateLimitType: SECOND_RATE_LIMIT,
-		RateLimit:     0,
+		IsRateLimited: true,
+		RateLimitType: MONTH_RATE_LIMIT,
+		RateLimit:     1000,
 		FuncGetIp:     getIpFromIpapi,
 		IsEnabled:     true,
 	}

--- a/pkg/ipfinder/ipproviders/provider.go
+++ b/pkg/ipfinder/ipproviders/provider.go
@@ -12,12 +12,12 @@ var IpProviders = []IpProvider{
 type RateLimitType int
 
 const (
-	SECOND_RATE_LIMIT = 0
-	MINUTE_RATE_LIMIT = 1
-	HOUR_RATE_LIMIT   = 2
-	DAY_RATE_LIMIT    = 3
-	WEEK_RATE_LIMIT   = 4
-	MONTH_RATE_LIMIT  = 5
+	SECOND_RATE_LIMIT = 1
+	MINUTE_RATE_LIMIT = 60 * SECOND_RATE_LIMIT
+	HOUR_RATE_LIMIT   = 60 * MINUTE_RATE_LIMIT
+	DAY_RATE_LIMIT    = 24 * HOUR_RATE_LIMIT
+	WEEK_RATE_LIMIT   = 7 * DAY_RATE_LIMIT
+	MONTH_RATE_LIMIT  = 30 * DAY_RATE_LIMIT
 )
 
 // GetIp is a function that returns the current IP
@@ -30,6 +30,7 @@ type IpProvider struct {
 	IsRateLimited bool
 	RateLimitType RateLimitType
 	RateLimit     uint
+	PeriodSizeSec float32
 	FuncGetIp     GetIp
 	IsEnabled     bool
 	LastUsage     int64


### PR DESCRIPTION
# Description
Adds rate limit management for rate limited APIs.
- When activating an API, its rate limit period is calculated. It is basically the interval at which an API can be used without hitting a rate limit.
- When choosing the next API to call, the algorithm will simply check if the next API in list can be used, if not, it will check for the next one.

Also added badge status to the README.md


## Checklist for the reviewers
- [x] Verify coding style/standard
- [ ] New tests have been added
- [ ] Check if tests if passed
- [x] Verify all workflow pass